### PR TITLE
Pass reduxEnhancers to redux createStore

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -19,13 +19,18 @@ export default function configureStore({
   initialState = {},
   history,
   middleware = [],
-  reducers = {}
+  reducers = {},
+  enhancers = [],
 }) {
   // Add history middleware
   const historyMiddleware = routerMiddleware(history);
   middleware.push(historyMiddleware);
-  
-  const store = createStore(createReducer(reducers), initialState, composeEnhancers(applyMiddleware(...middleware)));
+
+  const store = createStore(
+    createReducer(reducers),
+    initialState,
+    composeEnhancers(...enhancers, applyMiddleware(...middleware)),
+  );
   store.asyncReducers = reducers;
   return store;
 }


### PR DESCRIPTION
Passes along reduxEnhancers to `createStore`, they are already provided in [lib/client/client.js](https://github.com/Atyantik/pawjs/blob/df8fcd06c8ef996ccc175aa10b2afd2d35c24116/lib/client/client.js#L75) and [lib/server/prod.server.js](https://github.com/Atyantik/pawjs/blob/df8fcd06c8ef996ccc175aa10b2afd2d35c24116/lib/server/prod.server.js#L298). This just makes sure they make it all the way to redux