### PR TITLE
Remove PAW_CONFIG_PATH from sw.js.

### DIFF
--- a/src/webpack/plugins/sw-variables.js
+++ b/src/webpack/plugins/sw-variables.js
@@ -53,7 +53,7 @@ class SwVariables {
       if (compilation.assets[fileName]) {
         let src = compilation.assets[fileName].source();
 
-        const pawEnv = Object.keys(process.env).filter(x => x.indexOf('PAW_') !== -1);
+        const pawEnv = Object.keys(process.env).filter(x => x.indexOf('PAW_') !== -1 && x !== 'PAW_CONFIG_PATH');
         const env = {};
         pawEnv.forEach((k) => {
           env[k] = process.env[k];


### PR DESCRIPTION
To avoid exposing server paths on the front end this commit will remove it from sw.js.