### PR TITLE
feat(config): - add hotReload config setting (process.env.HOT_RELOAD)…

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,6 +20,7 @@ interface IConfig {
   hashedRoutes?: boolean;
   react?: string;
   noJS?: boolean;
+  hotReload?: boolean;
 }
 let config: IConfig = {};
 try {
@@ -83,6 +84,17 @@ config = {
     hashedRoutes: getBool(process.env.USE_HASHED_ROUTES, config.hashedRoutes),
     react: getBool(process.env.REACT_CDN) ? 'cdn' : config.react,
     noJS: getBool(process.env.DISABLE_JS, config.noJS),
+    /**
+     * Hor reload should be turned off by default in production env.
+     * Be careful, if you don’t use your app like SPA and turn on hotReload, then maximum number of websocket connections (HMR) is 6 (browser dependent).
+     * After that your new pages will not be dynamically imported
+     */
+    hotReload: getBool(
+      process.env.HOT_RELOAD,
+      typeof config.hotReload !== 'undefined'
+        ? config.hotReload
+        : process.env.NODE_ENV !== 'production',
+    ),
   },
 };
 

--- a/src/server/webpack-start.ts
+++ b/src/server/webpack-start.ts
@@ -38,6 +38,10 @@ wHandler
       wType: string,
       wConfigs: IPawjsWebpackConfig [],
     ) => {
+      if (!pawConfig.hotReload) {
+        return undefined;
+      }
+
       // Add eval devtool to all the configs
       wConfigs.forEach((wConfig: IPawjsWebpackConfig) => {
         const config = wConfig;
@@ -245,12 +249,14 @@ try {
   // res.locals but its not needed anyway.
   app.use(webMiddleware);
 
-  // Add hot middleware to the update
-  app.use(webpackHotMiddleware(webCompiler, {
-    log: false,
-    path: '/__hmr_update',
-    heartbeat: 2000,
-  }));
+  if (pawConfig.hotReload) {
+    // Add hot middleware to the update
+    app.use(webpackHotMiddleware(webCompiler, {
+      log: false,
+      path: '/__hmr_update',
+      heartbeat: 2000,
+    }));
+  }
 
   app.use(pawConfig.appRootUrl || '', express.static(serverOptions.contentBase));
 


### PR DESCRIPTION
… to turn off not necessary webpack configuration. By default process.env.NODE_ENV !== 'production'